### PR TITLE
refactor(hashmaps): reworks both hashmaps 

### DIFF
--- a/KMDFLycaniteFileFilter/IKashmap.h
+++ b/KMDFLycaniteFileFilter/IKashmap.h
@@ -7,6 +7,10 @@
 
 #include "Kashmap.h"
 
+/*
+* hashmap need to handle all mem access
+*/
+
 #define __HASHMAP_H__
 
 #define MAP_MISSING -3  /* No such element */

--- a/KMDFLycaniteFileFilter/IKashmap.h
+++ b/KMDFLycaniteFileFilter/IKashmap.h
@@ -104,10 +104,9 @@ extern "C" {
     /*
      * Remove an element with that key from the map
      */
-    static INT ihashmap_remove(map_t in, INT key, any_t* data_removed);
+    static INT ihashmap_remove(map_t in, INT key, any_t *data_removed);
 
     /* Deallocate the hashmap */
-    static INT ifree_data(any_t other, any_t data);
     static VOID ihashmap_free(map_t in);
 
     /* Return the length of the hashmap */
@@ -229,11 +228,6 @@ INT ihashmap_rehash(map_t in) {
 INT ihashmap_put(map_t in, INT key, any_t value) {
     INT index;
     hashmap_map* map;
-    PINT32 get;
-
-    if (ihashmap_get(in, key, (PVOID*)&get) != MAP_MISSING) {
-        free(get);
-    }
 
     /* Cast the hashmap */
     map = (hashmap_map*)in;
@@ -377,15 +371,8 @@ INT ihashmap_remove(map_t in, INT key, any_t *data_removed) {
     return MAP_MISSING;
 }
 
-/* Deallocate the hashmap */
-INT ifree_data(any_t other, any_t data) {
-    free(data);
-    return MAP_OK;
-}
-
 VOID ihashmap_free(map_t in) {
     hashmap_map* map = (hashmap_map*)in;
-    ihashmap_iterate(in, &ifree_data, NULL);
     free(map->data);
     free(map);
 }

--- a/KMDFLycaniteFileFilter/IKashmap.h
+++ b/KMDFLycaniteFileFilter/IKashmap.h
@@ -7,10 +7,6 @@
 
 #include "Kashmap.h"
 
-/*
-* hashmap need to handle all mem access
-*/
-
 #define __HASHMAP_H__
 
 #define MAP_MISSING -3  /* No such element */

--- a/KMDFLycaniteFileFilter/Kashmap.h
+++ b/KMDFLycaniteFileFilter/Kashmap.h
@@ -117,7 +117,7 @@ extern "C" {
     /// @return On success 0 is returned.
     static INT8 hashmap_remove(struct hashmap_s* CONST hashmap,
         CONST PCHAR key,
-        CONST UINT32 len
+        CONST UINT32 len,
         PVOID *data_removed) HASHMAP_USED;
 
     /// @brief Iterate over all the elements in a hashmap.
@@ -295,8 +295,7 @@ PVOID hashmap_get(CONST struct hashmap_s* CONST m, CONST PCHAR key,
 }
 
 INT8 hashmap_remove(struct hashmap_s* CONST m, CONST PCHAR key,
-    CONST UINT32 len
-    PVOID* data_removed) {
+    CONST UINT32 len, PVOID* data_removed) {
     UINT32 i;
     UINT32 curr;
 

--- a/KMDFLycaniteFileFilter/Kashmap.h
+++ b/KMDFLycaniteFileFilter/Kashmap.h
@@ -118,7 +118,8 @@ extern "C" {
     static INT8 hashmap_remove(struct hashmap_s* CONST hashmap,
         CONST PCHAR key,
         CONST UINT32 len,
-        PVOID *data_removed) HASHMAP_USED;
+        PVOID* data_removed,
+        PCHAR* key_removed) HASHMAP_USED;
 
     /// @brief Iterate over all the elements in a hashmap.
     /// @param hashmap The hashmap to iterate over.
@@ -295,7 +296,7 @@ PVOID hashmap_get(CONST struct hashmap_s* CONST m, CONST PCHAR key,
 }
 
 INT8 hashmap_remove(struct hashmap_s* CONST m, CONST PCHAR key,
-    CONST UINT32 len, PVOID* data_removed) {
+    CONST UINT32 len, PVOID* data_removed, PCHAR* key_removed) {
     UINT32 i;
     UINT32 curr;
 
@@ -308,6 +309,9 @@ INT8 hashmap_remove(struct hashmap_s* CONST m, CONST PCHAR key,
             if (hashmap_match_helper(&m->data[curr], key, len)) {
                 /* Return the data removed */
                 *data_removed = m->data[curr].data;
+
+                /* Return the key removed */
+                *key_removed = m->data[curr].key;
 
                 /* Blank out the fields including in_use */
                 Kmemset(&m->data[curr], 0, sizeof(struct hashmap_element_s));

--- a/KMDFLycaniteFileFilter/Kashmap.h
+++ b/KMDFLycaniteFileFilter/Kashmap.h
@@ -117,7 +117,8 @@ extern "C" {
     /// @return On success 0 is returned.
     static INT8 hashmap_remove(struct hashmap_s* CONST hashmap,
         CONST PCHAR key,
-        CONST UINT32 len) HASHMAP_USED;
+        CONST UINT32 len
+        PVOID *data_removed) HASHMAP_USED;
 
     /// @brief Iterate over all the elements in a hashmap.
     /// @param hashmap The hashmap to iterate over.
@@ -294,7 +295,8 @@ PVOID hashmap_get(CONST struct hashmap_s* CONST m, CONST PCHAR key,
 }
 
 INT8 hashmap_remove(struct hashmap_s* CONST m, CONST PCHAR key,
-    CONST UINT32 len) {
+    CONST UINT32 len
+    PVOID* data_removed) {
     UINT32 i;
     UINT32 curr;
 
@@ -305,6 +307,9 @@ INT8 hashmap_remove(struct hashmap_s* CONST m, CONST PCHAR key,
     for (i = 0; i < HASHMAP_MAX_CHAIN_LENGTH; i++) {
         if (m->data[curr].in_use) {
             if (hashmap_match_helper(&m->data[curr], key, len)) {
+                /* Return the data removed */
+                *data_removed = m->data[curr].data;
+
                 /* Blank out the fields including in_use */
                 Kmemset(&m->data[curr], 0, sizeof(struct hashmap_element_s));
 


### PR DESCRIPTION
We need to free data pointers in `free` and `destroy` hashmaps methods.
We need that the both hashmaps have **0 memory-leak** to be fully kernel safe.