### PR TITLE
feature(permissions-map): Permissions map function 

### DIFF
--- a/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.c
+++ b/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.c
@@ -1,5 +1,5 @@
 #include "Driver.h"
-#include "IKashmap.h"
+#include "Permissions.h"
 
 /* ======================================================
 *                       Filter Structs

--- a/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj
+++ b/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj
@@ -188,6 +188,7 @@
     <ClInclude Include="Kashmap.h" />
     <ClInclude Include="IKashmap.h" />
     <ClInclude Include="Permissions.h" />
+    <ClInclude Include="Utils.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj
+++ b/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="Driver.h" />
     <ClInclude Include="Kashmap.h" />
     <ClInclude Include="IKashmap.h" />
+    <ClInclude Include="Permissions.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj.filters
+++ b/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj.filters
@@ -43,5 +43,8 @@
     <ClInclude Include="IKashmap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Permissions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj.filters
+++ b/KMDFLycaniteFileFilter/KMDFLycaniteFileFilter.vcxproj.filters
@@ -46,5 +46,8 @@
     <ClInclude Include="Permissions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/KMDFLycaniteFileFilter/Kashmap.h
+++ b/KMDFLycaniteFileFilter/Kashmap.h
@@ -7,7 +7,7 @@
 #pragma warning(push, 0)
 #pragma warning(disable : 4668)
 #endif
-#include <ntddk.h>
+#include "Utils.h"
 
 #if (defined(_MSC_VER) && defined(__AVX__)) ||                                 \
     (!defined(_MSC_VER) && defined(__SSE4_2__))
@@ -62,21 +62,6 @@ struct hashmap_s {
 #if defined(__cplusplus)
 extern "C" {
 #endif
-
-    // override calloc for kernel
-    PVOID calloc(SIZE_T elementCount, SIZE_T elementSize);
-    
-    // override free for kernel
-    VOID free(PVOID mem);
-
-    // override memcpy for kernel
-    PVOID Kmemcpy(PVOID destination, CONST PVOID source, SIZE_T size);
-
-    // override memcmp
-    INT32 Kmemcmp(CONST PVOID pointer1, CONST PVOID pointer2, SIZE_T size);
-
-    // override memset
-    PVOID Kmemset(PVOID pointer, INT8 value, SIZE_T count);
 
     /// @brief Create a hashmap.
     /// @param initial_size The initial size of the hashmap. Must be a power of two.
@@ -180,55 +165,6 @@ extern "C" {
 #define HASHMAP_PTR_CAST(type, x) ((type)x)
 #define HASHMAP_NULL 0
 #endif
-
-PVOID malloc(SIZE_T memory_size) {
-    return ExAllocatePoolWithTag(NonPagedPoolNx, memory_size, 'aloc');
-}
-
-PVOID calloc(SIZE_T elementCount, SIZE_T elementSize) {
-    SIZE_T total_size = elementCount * elementSize;
-    PCHAR mem = (PCHAR)ExAllocatePoolWithTag(NonPagedPoolNx, elementCount * elementSize, 'aloc');
-
-    // init data allocated with 0 like calloc
-    for (SIZE_T i = 0; mem != NULL && i < total_size; i++) {
-        mem[i] = 0;
-    }
-
-    return (PVOID)mem;
-}
-
-VOID free(PVOID mem) {
-    if (mem != NULL) {
-        ExFreePoolWithTag(mem, 'aloc');
-    }
-}
-
-PVOID Kmemcpy(PVOID destination, CONST PVOID source, SIZE_T size) {
-    for (SIZE_T i = 0; destination != NULL && i < size; i++) {
-        ((PCHAR)destination)[i] = ((PCHAR)source)[i];
-    }
-    
-    return destination;
-}
-
-// override memcmp
-INT32 Kmemcmp(CONST PVOID pointer1, CONST PVOID pointer2, SIZE_T size) {
-    if (pointer1 == pointer2) return 0;
-    for (SIZE_T i = 0; i < size; i++) {
-        if (((PCHAR)pointer1)[i] != ((PCHAR)pointer2)[i]) {
-            return (((PCHAR)pointer1)[i] - ((PCHAR)pointer2)[i]);
-        }
-    }
-    return 0;
-}
-
-// override memset
-PVOID Kmemset(PVOID pointer, INT8 value, SIZE_T count) {
-    for (SIZE_T i = 0; pointer != NULL && i < count; i++) {
-        ((PCHAR)pointer)[i] = value;
-    }
-    return (pointer);
-}
 
 INT8 hashmap_create(CONST UINT32 initial_size,
     struct hashmap_s* CONST out_hashmap) {

--- a/KMDFLycaniteFileFilter/Permissions.h
+++ b/KMDFLycaniteFileFilter/Permissions.h
@@ -6,8 +6,6 @@
 extern "C" {
 #endif
 
-	static UINT32 my_strlen(CONST PCHAR str);
-
 	static UINT64 getFilePermission(CONST PCHAR path, CONST struct hashmap_s* map);
 	static UINT64 getFilePermissionWithFree(CONST PCHAR path, CONST struct hashmap_s* map);
 
@@ -16,16 +14,6 @@ extern "C" {
 #if defined(__cplusplus)
 }
 #endif
-
-UINT32 my_strlen(CONST PCHAR str)
-{
-	UINT32 len = 0;
-
-	for (SIZE_T i = 0; str[i] != '\0'; i++) {
-		len += 1;
-	}
-	return len;
-}
 
 UINT64 getFilePermission(CONST PCHAR path, CONST struct hashmap_s* map)
 {
@@ -36,7 +24,6 @@ UINT64 getFilePermission(CONST PCHAR path, CONST struct hashmap_s* map)
 	}
 	else {
 		PCHAR parent = NULL;
-		/* ajouter un bool ou une connerie du genre pour free parent quand la récursive se fait */
 		if ((parent = hasParentFolder(path, map)) != NULL) {
 			return getFilePermissionWithFree(parent, map);
 		}
@@ -56,11 +43,11 @@ UINT64 getFilePermissionWithFree(CONST PCHAR path, CONST struct hashmap_s* map)
 	}
 	else {
 		PCHAR parent = NULL;
-		/* ajouter un bool ou une connerie du genre pour free parent quand la récursive se fait */
 		if ((parent = hasParentFolder(path, map)) != NULL) {
 			return getFilePermissionWithFree(parent, map);
 		}
 		else {
+			free((PVOID)path);
 			return 0; // return no permissions
 		}
 	}

--- a/KMDFLycaniteFileFilter/Permissions.h
+++ b/KMDFLycaniteFileFilter/Permissions.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "IKashmap.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+	static UINT32 my_strlen(CONST PCHAR str);
+
+	static UINT64 getFilePermission(CONST PCHAR path, CONST struct hashmap_s* map);
+	static UINT64 getFilePermissionWithFree(CONST PCHAR path, CONST struct hashmap_s* map);
+
+	static PCHAR hasParentFolder(CONST PCHAR path, CONST struct hashmap_s* map);
+
+#if defined(__cplusplus)
+}
+#endif
+
+UINT32 my_strlen(CONST PCHAR str)
+{
+	UINT32 len = 0;
+
+	for (SIZE_T i = 0; str[i] != '\0'; i++) {
+		len += 1;
+	}
+	return len;
+}
+
+UINT64 getFilePermission(CONST PCHAR path, CONST struct hashmap_s* map)
+{
+	PVOID path_permissions = hashmap_get(map, path, my_strlen(path));
+
+	if (path_permissions != HASHMAP_NULL) {
+		return *(UINT64*)path_permissions;
+	}
+	else {
+		PCHAR parent = NULL;
+		/* ajouter un bool ou une connerie du genre pour free parent quand la récursive se fait */
+		if ((parent = hasParentFolder(path, map)) != NULL) {
+			return getFilePermissionWithFree(parent, map);
+		}
+		else {
+			return 0; // return no permissions
+		}
+	}
+}
+
+UINT64 getFilePermissionWithFree(CONST PCHAR path, CONST struct hashmap_s* map)
+{
+	PVOID path_permissions = hashmap_get(map, path, my_strlen(path));
+
+	if (path_permissions != HASHMAP_NULL) {
+		free((PVOID)path);
+		return *(UINT64*)path_permissions;
+	}
+	else {
+		PCHAR parent = NULL;
+		/* ajouter un bool ou une connerie du genre pour free parent quand la récursive se fait */
+		if ((parent = hasParentFolder(path, map)) != NULL) {
+			return getFilePermissionWithFree(parent, map);
+		}
+		else {
+			return 0; // return no permissions
+		}
+	}
+}
+
+PCHAR hasParentFolder(CONST PCHAR path, CONST struct hashmap_s* map)
+{
+	SIZE_T memsize = my_strlen(path);
+	PCHAR parent = (PCHAR)calloc(memsize, 1);
+
+	Kmemcpy((PVOID)parent, (PVOID)path, memsize);
+	for (SIZE_T i = memsize - 2; i > 0; i--) {
+		if (((PCHAR)parent)[i] == '\\') {
+			parent[i] = '\0';
+			if (hashmap_get(map, parent, my_strlen(parent)) != HASHMAP_NULL) {
+				return parent;
+			}
+		}
+	}
+	free(parent);
+	return NULL;
+}

--- a/KMDFLycaniteFileFilter/Permissions.h
+++ b/KMDFLycaniteFileFilter/Permissions.h
@@ -55,7 +55,7 @@ UINT64 getFilePermissionWithFree(CONST PCHAR path, CONST struct hashmap_s* map)
 
 PCHAR hasParentFolder(CONST PCHAR path, CONST struct hashmap_s* map)
 {
-	SIZE_T memsize = my_strlen(path);
+	SIZE_T memsize = my_strlen(path) + 1;
 	PCHAR parent = (PCHAR)calloc(memsize, 1);
 
 	Kmemcpy((PVOID)parent, (PVOID)path, memsize);

--- a/KMDFLycaniteFileFilter/Utils.h
+++ b/KMDFLycaniteFileFilter/Utils.h
@@ -60,9 +60,7 @@ VOID free(PVOID mem) {
 }
 
 PVOID Kmemcpy(PVOID destination, CONST PVOID source, SIZE_T size) {
-    for (SIZE_T i = 0; destination != NULL && i < size; i++) {
-        ((PCHAR)destination)[i] = ((PCHAR)source)[i];
-    }
+    RtlCopyMemory(destination, source, size);
 
     return destination;
 }

--- a/KMDFLycaniteFileFilter/Utils.h
+++ b/KMDFLycaniteFileFilter/Utils.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <ntddk.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+	static UINT32 my_strlen(CONST PCHAR str);
+
+    // override calloc for kernel
+    static PVOID calloc(SIZE_T elementCount, SIZE_T elementSize);
+
+    // override free for kernel
+    static VOID free(PVOID mem);
+
+    // override memcpy for kernel
+    static PVOID Kmemcpy(PVOID destination, CONST PVOID source, SIZE_T size);
+
+    // override memcmp
+    static INT32 Kmemcmp(CONST PVOID pointer1, CONST PVOID pointer2, SIZE_T size);
+
+    // override memset
+    static PVOID Kmemset(PVOID pointer, INT8 value, SIZE_T count);
+
+#if defined(__cplusplus)
+}
+#endif
+
+UINT32 my_strlen(CONST PCHAR str)
+{
+	UINT32 len = 0;
+
+	for (SIZE_T i = 0; str[i] != '\0'; i++) {
+		len += 1;
+	}
+	return len;
+}
+
+PVOID malloc(SIZE_T memory_size) {
+    return ExAllocatePoolWithTag(NonPagedPoolNx, memory_size, 'aloc');
+}
+
+PVOID calloc(SIZE_T elementCount, SIZE_T elementSize) {
+    SIZE_T total_size = elementCount * elementSize;
+    PCHAR mem = (PCHAR)ExAllocatePoolWithTag(NonPagedPoolNx, elementCount * elementSize, 'aloc');
+
+    // init data allocated with 0 like calloc
+    for (SIZE_T i = 0; mem != NULL && i < total_size; i++) {
+        mem[i] = 0;
+    }
+
+    return (PVOID)mem;
+}
+
+VOID free(PVOID mem) {
+    if (mem != NULL) {
+        ExFreePoolWithTag(mem, 'aloc');
+    }
+}
+
+PVOID Kmemcpy(PVOID destination, CONST PVOID source, SIZE_T size) {
+    for (SIZE_T i = 0; destination != NULL && i < size; i++) {
+        ((PCHAR)destination)[i] = ((PCHAR)source)[i];
+    }
+
+    return destination;
+}
+
+// override memcmp
+INT32 Kmemcmp(CONST PVOID pointer1, CONST PVOID pointer2, SIZE_T size) {
+    if (pointer1 == pointer2) return 0;
+    for (SIZE_T i = 0; i < size; i++) {
+        if (((PCHAR)pointer1)[i] != ((PCHAR)pointer2)[i]) {
+            return (((PCHAR)pointer1)[i] - ((PCHAR)pointer2)[i]);
+        }
+    }
+    return 0;
+}
+
+// override memset
+PVOID Kmemset(PVOID pointer, INT8 value, SIZE_T count) {
+    for (SIZE_T i = 0; pointer != NULL && i < count; i++) {
+        ((PCHAR)pointer)[i] = value;
+    }
+    return (pointer);
+}


### PR DESCRIPTION
Map in order to get permissions from **file parent** or **parent folder path** :

Example :

```cpp
    struct hashmap_s map;
    CHAR path[] = "C:\\Users\\Moi\\Desktop\\Lycanite\\HelloWorld\\hw.exe";
    UINT64 perm = 65;

    CHAR path2[] = "C:\\Users\\Moi\\Desktop\\Lycanite\\Yeet";
    UINT64 perm2 = 85;

    hashmap_create(8, &map);

    hashmap_put(&map, path, my_strlen(path), (PVOID)&perm);
    hashmap_put(&map, path2, my_strlen(path2), (PVOID)&perm2);

    perm = getFilePermission("C:\\Users\\Moi\\Desktop\\Lycanite\\HelloWorld\\hw.exe", &map);

    if (perm == 65)
        DbgPrintEx(0, 0, "Perm is 65."); // this on output
    else if (perm == 666)
        DbgPrintEx(0, 0, "Perm is 666.");
    else
        DbgPrintEx(0, 0, "Perm is not correctly get.");

    perm = getFilePermission("C:\\Users\\Moi\\Desktop\\Lycanite\\Yeet\\hw.exe", &map);

    if (perm == 85)
        DbgPrintEx(0, 0, "Perm is 85."); // this on output
    else if (perm == 666)
        DbgPrintEx(0, 0, "Perm is 666.");
    else
        DbgPrintEx(0, 0, "Perm is not correctly get.");

    hashmap_destroy(&map);
```